### PR TITLE
Let Implementation

### DIFF
--- a/example_spec.rb
+++ b/example_spec.rb
@@ -11,3 +11,22 @@ describe "expectations" do
     end.to raise_error(ArgumentError)
   end
 end
+
+describe "let" do
+  let(:five) { 5 }
+  let(:random) { rand }
+
+  it 'is available inside the test' do
+    expect(five).to eq(5)
+  end
+
+  it 'always returns the same object' do
+    expect(random).to eq random
+  end
+
+  it "still fails when method don't exist" do
+    expect do
+      method_that_dont_exist
+    end.to raise_error(NameError)
+  end
+end

--- a/runner.rb
+++ b/runner.rb
@@ -13,6 +13,8 @@ class Describe
     @lets = {}
   end
 
+  # instance_eval, runs the block in context of describe object
+  # instance_eval is mainly used to run blocks
   def run
     puts @description
     # @block.call
@@ -39,6 +41,7 @@ class It
   def run
     begin
       $stdout.write " - #{@description}"
+      # @block.call
       instance_eval(&@block)
       puts " #{GREEN}(ok)#{RESET}"
     rescue Exception => e

--- a/runner.rb
+++ b/runner.rb
@@ -1,18 +1,77 @@
+GREEN = "\e[32m"
+RED   = "\e[31m"
+RESET = "\e[0m"
+
 def describe(description, &block)
-  puts description
-  block.call
+  Describe.new(description, block).run
 end
 
-def expect(actual=nil, &block)
-  Actual.new(actual || block)
+class Describe
+  def initialize(description, block)
+    @description = description
+    @block = block
+    @lets = {}
+  end
+
+  def run
+    puts @description
+    # @block.call
+    instance_eval(&@block) # check out why this works
+  end
+
+  def it(description, &block)
+    It.new(description, block, @lets).run
+  end
+
+  def let(name, &block)
+    @lets[name] = block
+  end
 end
 
-def eq(expected)
-  Expectations::Equal.new(expected)
-end
+class It
+  def initialize(description, block, lets)
+    @description = description
+    @block = block
+    @lets = lets
+    @lets_cache = {}
+  end
 
-def raise_error(exception_class)
-  Expectations::Error.new(exception_class)
+  def run
+    begin
+      $stdout.write " - #{@description}"
+      instance_eval(&@block)
+      puts " #{GREEN}(ok)#{RESET}"
+    rescue Exception => e
+      puts " #{RED}(fail)#{RESET}"
+      puts [
+        "#{RED}* Backtrace: #{RESET}",
+        e.backtrace.reverse.map { |line| "#{RED}|#{RESET} #{line}" },
+        "#{RED}* #{e} #{RESET}",
+      ].flatten.map { |line| "\t#{line}" }.join("\n")
+    end
+  end
+
+  def expect(actual=nil, &block)
+    Actual.new(actual || block)
+  end
+
+  def eq(expected)
+    Expectations::Equal.new(expected)
+  end
+
+  def raise_error(exception_class)
+    Expectations::Error.new(exception_class)
+  end
+
+  def method_missing(name)
+    if @lets_cache.key?(name)
+      @lets_cache.fetch(name)
+    else
+      value = instance_eval(&@lets.fetch(name) { super })
+      @lets_cache[name] = value
+      value
+    end
+  end
 end
 
 class Actual
@@ -22,25 +81,6 @@ class Actual
 
   def to(expectation)
     expectation.run(@actual)
-  end
-end
-
-GREEN = "\e[32m"
-RED   = "\e[31m"
-RESET = "\e[0m"
-
-def it(description, &block)
-  begin
-    $stdout.write " - #{description}"
-    block.call
-    puts " #{GREEN}(ok)#{RESET}"
-  rescue Exception => e
-    puts " #{RED}(fail)#{RESET}"
-    puts [
-      "#{RED}* Backtrace: #{RESET}",
-      e.backtrace.reverse.map { |line| "#{RED}|#{RESET} #{line}" },
-      "#{RED}* #{e} #{RESET}",
-    ].flatten.map { |line| "\t#{line}" }.join("\n")
   end
 end
 


### PR DESCRIPTION
1. Move methods  'describe', 'it' , 'expect' declared from Main object into it's own classes
2. Usage of method_missing, to evaluate ``` expect(five).to eq(5)```